### PR TITLE
Fix: Tests on Firefox and Hybrid setup

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,15 +3,13 @@
   "description": "A group of elements to support intercepting ajax requests for injecting headers or handling responses globally.",
   "main": "all-imports.html",
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.9.0 || ^2.0.0"
+    "polymer": "Polymer/polymer#^1.9 || ^2.0"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0 || ^2.0.0",
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0 || ^2.0.0",
-    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0 || ^2.0.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0 || ^3.0.0-rc.1",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0 || ^2.0",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0 || ^2.0",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0 || ^1.0.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
   "variants": {
     "1.x": {
@@ -21,13 +19,14 @@
       "devDependencies": {
         "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-        "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
-        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       },
       "resolutions": {
-        "test-fixture": "^1.0.0"
+        "webcomponentsjs": "^0.7.0"
       }
     }
+  },
+  "resolutions": {
+    "webcomponentsjs": "^1.0.0"
   }
 }

--- a/mtz-ajax-interceptor-behavior.html
+++ b/mtz-ajax-interceptor-behavior.html
@@ -1,7 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 
 <script>
-  window.mtz = mtz || {};
+  window.mtz = window.mtz || {};
 
   /**
    * `mtz.AjaxInterceptorBehavior`

--- a/mtz-status-code-interceptor.html
+++ b/mtz-status-code-interceptor.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="./mtz-interceptor-behavior.html">
-
+<link rel="import" href="mtz-interceptor-behavior.html">
 
 <!--
 `mtz-status-code-interceptor`

--- a/test/index.html
+++ b/test/index.html
@@ -9,10 +9,12 @@
   <body>
     <script>
       WCT.loadSuites([
-        'mtz-interceptor_test.html',
+        'mtz-ajax-interceptor_test.html?dom=shadow',
+        'mtz-ajax-interceptor_test.html?wc-shadydom=true&wc-ce=true',
         'mtz-interceptor_test.html?dom=shadow',
-        'mtz-status-code-interceptor_test.html',
+        'mtz-interceptor_test.html?wc-shadydom=true&wc-ce=true',
         'mtz-status-code-interceptor_test.html?dom=shadow',
+        'mtz-status-code-interceptor_test.html?wc-shadydom=true&wc-ce=true',
       ]);
     </script>
   </body>

--- a/test/mtz-ajax-interceptor.html
+++ b/test/mtz-ajax-interceptor.html
@@ -1,0 +1,11 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../mtz-ajax-interceptor-behavior.html">
+
+<dom-module id="mtz-ajax-interceptor">
+  <script>
+    Polymer({
+      is: 'mtz-ajax-interceptor',
+      behaviors: [mtz.AjaxInterceptorBehavior]
+    });
+  </script>
+</dom-module>

--- a/test/mtz-ajax-interceptor_test.html
+++ b/test/mtz-ajax-interceptor_test.html
@@ -9,18 +9,9 @@
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
-    <link rel="import" href="../mtz-ajax-interceptor-behavior.html">
+    <link rel="import" href="mtz-ajax-interceptor.html">
   </head>
   <body>
-    <dom-module id="mtz-ajax-interceptor">
-      <script>
-        Polymer({
-          is: 'mtz-ajax-interceptor',
-          behaviors: [mtz.AjaxInterceptorBehavior]
-        });
-      </script>
-    </dom-module>
-
     <test-fixture id="basic">
       <template>
         <mtz-ajax-interceptor></mtz-ajax-interceptor>

--- a/test/mtz-interceptor.html
+++ b/test/mtz-interceptor.html
@@ -1,0 +1,11 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../mtz-interceptor-behavior.html">
+
+<dom-module id="mtz-interceptor">
+  <script>
+    Polymer({
+      is: 'mtz-interceptor',
+      behaviors: [mtz.InterceptorBehavior]
+    });
+  </script>
+</dom-module>

--- a/test/mtz-interceptor_test.html
+++ b/test/mtz-interceptor_test.html
@@ -9,18 +9,9 @@
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
-    <link rel="import" href="../mtz-interceptor-behavior.html">
+    <link rel="import" href="mtz-interceptor.html">
   </head>
   <body>
-    <dom-module id="mtz-interceptor">
-      <script>
-        Polymer({
-          is: 'mtz-interceptor',
-          behaviors: [mtz.InterceptorBehavior]
-        });
-      </script>
-    </dom-module>
-
     <test-fixture id="basic">
       <template>
         <mtz-interceptor></mtz-interceptor>


### PR DESCRIPTION
- Firefox didn't like your inline elements. Moved out into separate files. These files will also be useful for demo purposes.
- Adjusted the bower.json setup for resolutions and removed extra deps
- Fixed a bad reference in mtz-ajax-interceptor
- Modified how the tests are initiated to use the new web component setup.