### PR TITLE
Fix: Rewrite for non-localhost

### DIFF
--- a/mtz-url-rewrite-interceptor.html
+++ b/mtz-url-rewrite-interceptor.html
@@ -56,9 +56,9 @@ presend event for iron-ajax.
         /* Used in `String.replace` as the pattern to match. This value is converted to `RegExp` */
         pattern: String,
         /* Used in `String.replace` as the replacement `Function` */
-        replacer: String,
+        replacer: Function,
         /* Used in `String.replace` as the replacement `String` if replacer `Function` was not passed */
-        replacement: Function,
+        replacement: String,
         /* Pattern used to match the host for determining if running on a localhost */
         _localPattern: {
           type: String,

--- a/mtz-url-rewrite-interceptor.html
+++ b/mtz-url-rewrite-interceptor.html
@@ -108,9 +108,9 @@ presend event for iron-ajax.
         isLocal = this.__isLocal, localBaseUrl = this.localBaseUrl, baseUrl = this.baseUrl,
         pattern = this.pattern, replacement = this.replacement, host = this.__host) {
         // Determine baseUrl
-        baseUrl = isLocal ?
+        baseUrl = (isLocal ?
           localBaseUrl :
-          (baseUrl || host.replace(new RegExp(pattern), replacement));
+          (baseUrl || (pattern && host.replace(new RegExp(pattern), replacement)))) || host;
         // Remove any trailing slash on baseUrl
         baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
 

--- a/mtz-url-rewrite-interceptor.html
+++ b/mtz-url-rewrite-interceptor.html
@@ -118,7 +118,7 @@ presend event for iron-ajax.
           baseUrl = baseUrl.replace(new RegExp(pattern), replacerValue);
         }
         // Remove any trailing slash on baseUrl
-        baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+        baseUrl = (baseUrl || '').endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
 
         // Build our Query String
         let queryString = this.__getQueryString(url);

--- a/mtz-url-rewrite-interceptor.html
+++ b/mtz-url-rewrite-interceptor.html
@@ -55,8 +55,10 @@ presend event for iron-ajax.
         queryParams: Object,
         /* Used in `String.replace` as the pattern to match. This value is converted to `RegExp` */
         pattern: String,
-        /* Used in `String.replace` as the replacement `String` or `Function` */
-        replacement: Object,
+        /* Used in `String.replace` as the replacement `Function` */
+        replacer: String,
+        /* Used in `String.replace` as the replacement `String` if replacer `Function` was not passed */
+        replacement: Function,
         /* Pattern used to match the host for determining if running on a localhost */
         _localPattern: {
           type: String,
@@ -66,14 +68,14 @@ presend event for iron-ajax.
         __isLocal: {
           type: Boolean,
           readOnly: true,
-          computed: '__computeIsLocal(_localPattern, __host)',
+          computed: '__computeIsLocal(_localPattern, __origin)',
         },
-        /* Stores the host for determining isLocal */
-        __host: {
+        /* Stores the origin for determining isLocal */
+        __origin: {
           type: String,
           readOnly: true,
           value() {
-            return location.host;
+            return location.origin;
           },
         },
       },
@@ -100,17 +102,21 @@ presend event for iron-ajax.
        * @param {String} [localBaseUrl=this.localBaseUrl]
        * @param {String} [baseUrl=this.baseUrl]
        * @param {String|RegExp} [pattern=this.pattern]
-       * @param {String|Function} [replacement=this.replacement]
-       * @param {String} [host=this.__host]
+       * @param {Function} [replacer=this.replacer]
+       * @param {String} [replacement=this.replacement]
+       * @param {String} [origin=this.__origin]
        * @return {String}
        */
       _rewriteUrl(url, rewriteMatcher = this.rewriteMatcher,
         isLocal = this.__isLocal, localBaseUrl = this.localBaseUrl, baseUrl = this.baseUrl,
-        pattern = this.pattern, replacement = this.replacement, host = this.__host) {
+        pattern = this.pattern, replacer = this.replacer, replacement = this.replacement, origin = this.__origin) {
         // Determine baseUrl
-        baseUrl = (isLocal ?
-          localBaseUrl :
-          (baseUrl || (pattern && host.replace(new RegExp(pattern), replacement)))) || host;
+        baseUrl = isLocal ? localBaseUrl : baseUrl || origin;
+        // Handle pattern replacement if provided
+        const replacerValue = replacer || replacement;
+        if (pattern && replacerValue) {
+          baseUrl = baseUrl.replace(new RegExp(pattern), replacerValue);
+        }
         // Remove any trailing slash on baseUrl
         baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
 
@@ -145,7 +151,7 @@ presend event for iron-ajax.
         let value;
         Object.keys(params || {}).forEach((param) => {
           value = params[param];
-          value = typeof value === 'function' ? value(this.__isLocal, this.__host, url) : value;
+          value = typeof value === 'function' ? value(this.__isLocal, this.__origin, url) : value;
 
           param = window.encodeURIComponent(param);
           if (Array.isArray(value)) {

--- a/test/mtz-url-rewrite-interceptor_test.html
+++ b/test/mtz-url-rewrite-interceptor_test.html
@@ -120,6 +120,19 @@
             expect(element._rewriteUrl('/api/rest/resource?oKey=oValue', undefined, true))
               .to.equal(`LOCAL_BASE_URL/api/rest/resource?oKey=oValue&key=value&key2=value2`);
           });
+          it('should properly rewrite the url', () => {
+            element.__getQueryString = sinon.stub().returns('');
+            expect(
+              element._rewriteUrl('/api/rest/participants/~/login',
+                                  '/api/rest/',
+                                  false,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  undefined,
+                                  'https://d-demo-ci.salesnext.com')).to
+              .equal('https://d-demo-ci.salesnext.com/api/rest/participants/~/login');
+          });
         });
         describe('__getQueryString(url, [params])', () => {
           it('should return a properly serialized string', () => {
@@ -146,7 +159,7 @@
                 return url;
               },
             });
-            expect(queryString).to.equal(`local=Y&host=localhost&url=%2Fresource`);
+            expect(queryString).to.equal(`local=Y&host=http&url=%2Fresource`);
           });
         });
       });

--- a/test/mtz-url-rewrite-interceptor_test.html
+++ b/test/mtz-url-rewrite-interceptor_test.html
@@ -79,59 +79,73 @@
             expect(element._rewriteUrl).not.be.called;
           });
         });
-        describe('_rewriteUrl(url, [rewriteMatcher], [isLocal], [localBaseUrl], [baseUrl], [pattern], [replacement], [host])', () => {
+        describe('_rewriteUrl(url, [rewriteMatcher], [isLocal], [localBaseUrl], [baseUrl], [pattern], [replacer], [replacement], [origin])', () => {
+          let localBaseUrl, baseUrl;
+
           beforeEach(() => {
-            element.localBaseUrl = 'LOCAL_BASE_URL';
+            localBaseUrl = 'http://LOCAL_BASE_URL.com';
+            baseUrl = 'https://BASE_URL.com';
           });
           it('should not rewrite the url if it doesn\'t match the url', () => {
             expect(element._rewriteUrl('/api/rest/resource', '/diff', true))
               .to.equal(`/api/rest/resource`);
           })
           it('should use the local base url when isLocal', () => {
-            element.baseUrl = 'BASE_URL';
+            element.baseUrl = baseUrl;
+            element.localBaseUrl = localBaseUrl;
             expect(element._rewriteUrl('/api/rest/resource', undefined, true))
               .to.equal(`${element.localBaseUrl}/api/rest/resource`);
           });
           it('should use the base url when not isLocal and base url is set', () => {
-            element.baseUrl = 'BASE_URL';
+            element.baseUrl = baseUrl;
+            element.localBaseUrl = localBaseUrl;
             expect(element._rewriteUrl('/api/rest/resource', undefined, false))
               .to.equal(`${element.baseUrl}/api/rest/resource`);
           });
           it('should rewrite the host if not local and no base url', () => {
-            expect(element._rewriteUrl('/api/rest/resource', undefined, false, undefined, undefined, '^(.+?)\\.', '$1-api.', 'subdomain.domain.com'))
-              .to.equal(`subdomain-api.domain.com/api/rest/resource`);
+            element.localBaseUrl = localBaseUrl;
+            expect(element._rewriteUrl('/api/rest/resource', undefined, false, undefined, undefined, '^(.+?)\\.', undefined, '$1-api.', 'http://subdomain.domain.com'))
+              .to.equal(`http://subdomain-api.domain.com/api/rest/resource`);
           });
           it('should rewrite the url without removing matcher', () => {
-            element.baseUrl = 'BASE_URL';
+            element.baseUrl = baseUrl;
+            element.localBaseUrl = localBaseUrl;
             expect(element._rewriteUrl('/api/rest/resource', '/api/rest', false))
               .to.equal(`${element.baseUrl}/api/rest/resource`);
           });
           it('should not modify the url if no queryString is generated', () => {
+            element.baseUrl = baseUrl;
+            element.localBaseUrl = localBaseUrl;
             expect(element._rewriteUrl('/api/rest/resource', undefined, true))
-              .to.equal(`LOCAL_BASE_URL/api/rest/resource`);
+              .to.equal(`${element.localBaseUrl}/api/rest/resource`);
           });
           it('should modify the url if queryString is generated', () => {
+            element.baseUrl = baseUrl;
+            element.localBaseUrl = localBaseUrl;
             element.__getQueryString = sinon.stub().returns('key=value&key2=value2');
             expect(element._rewriteUrl('/api/rest/resource', undefined, true))
-              .to.equal(`LOCAL_BASE_URL/api/rest/resource?key=value&key2=value2`);
+              .to.equal(`${element.localBaseUrl}/api/rest/resource?key=value&key2=value2`);
           });
           it('should modify the url if queryString is generated', () => {
+            element.baseUrl = baseUrl;
+            element.localBaseUrl = localBaseUrl;
             element.__getQueryString = sinon.stub().returns('key=value&key2=value2');
             expect(element._rewriteUrl('/api/rest/resource?oKey=oValue', undefined, true))
-              .to.equal(`LOCAL_BASE_URL/api/rest/resource?oKey=oValue&key=value&key2=value2`);
+              .to.equal(`${element.localBaseUrl}/api/rest/resource?oKey=oValue&key=value&key2=value2`);
           });
           it('should properly rewrite the url', () => {
             element.__getQueryString = sinon.stub().returns('');
             expect(
-              element._rewriteUrl('/api/rest/participants/~/login',
+              element._rewriteUrl('/api/rest/login',
                                   '/api/rest/',
                                   false,
                                   undefined,
                                   undefined,
+                                  '.website.com',
                                   undefined,
-                                  undefined,
-                                  'https://d-demo-ci.salesnext.com')).to
-              .equal('https://d-demo-ci.salesnext.com/api/rest/participants/~/login');
+                                  '-api.website.com',
+                                  'https://d-demo.website.com')).to
+              .equal('https://d-demo-api.website.com/api/rest/login');
           });
         });
         describe('__getQueryString(url, [params])', () => {


### PR DESCRIPTION
- `replacement` didn't handle `String`s properly when labelled as `Object`
     - Split it apart into `replacer` as a `Function` and `replacement` as a `String`
- `__host` was just the host and thus missing `protocol`
    - Switch to use `location.origin` which includes the `protocol`
- Fallback to `origin` if `baseUrl` and `localBaseUrl` are not defined.