### PR TITLE
New: setRequestHeader

### DIFF
--- a/mtz-auth-interceptor.html
+++ b/mtz-auth-interceptor.html
@@ -32,7 +32,11 @@ An implementation of the mtz.InterceptorBehavior that injects auth headers based
           value: 'Authorization'
         },
         /* The value to associate with the provided header */
-        value: String
+        value: String,
+        setRequestHeader: {
+          type: Boolean,
+          value: false,
+        },
       },
       /**
        * Checks the event to see if event.target has with-auth set, if so then _applyHeader is called.
@@ -55,8 +59,14 @@ An implementation of the mtz.InterceptorBehavior that injects auth headers based
        */
       _applyHeader(event, eventName) {
         const path = (this.events.find((item) => item.name === eventName) || {}).path;
-        if (path)
-          this.set(`${path}.${this.key}`, this.value, event);
+        if (path) {
+          if (!this.setRequestHeader) {
+            this.set(`${path}.${this.key}`, this.value, event);
+          } else {
+            const xhr = this.get(path, event);
+            xhr.setRequestHeader(this.key, this.value);
+          }
+        }
       }
     });
   </script>

--- a/test/mtz-auth-interceptor_test.html
+++ b/test/mtz-auth-interceptor_test.html
@@ -28,13 +28,24 @@
           },
           composed: true,
         });
+        const vaadinEvent = new CustomEvent(vaadinEventName = 'vaadin-request', {
+          detail: {
+            xhr: {},
+          },
+          composed: true,
+        });
 
         beforeEach(() => {
-          event.detail.options.headers = {}
+          event.detail.options.headers = {};
+          vaadinEvent.detail.xhr.setRequestHeader = sinon.spy();
           // Append for shady DOM;
           document.body.appendChild(el);
           el.dispatchEvent(event);
           element = fixture('basic');
+          element.events.push({
+            name: 'vaadin-request',
+            path: 'detail.xhr',
+          });
         });
         afterEach(() => {
           document.body.removeChild(el);
@@ -66,6 +77,13 @@
             element.value = 'value';
             element._applyHeader(event, eventName);
             expect(event.detail.options.headers[element.key]).to.equal(element.value);
+          });
+          it('should set the request header when setRequestHeader attr is set', () => {
+            element.key = 'key';
+            element.value = 'value';
+            element.setRequestHeader = true;
+            element._applyHeader(vaadinEvent, vaadinEventName);
+            expect(vaadinEvent.detail.xhr.setRequestHeader).to.have.been.calledWith(element.key, element.value);
           });
         });
       });


### PR DESCRIPTION
Allow handling of XHR `setRequestHeader`.

Do we want to handle the `setRequestHeader` automatically if it exists on the path?

**TODO:**

- [x] Tests