### PR TITLE
Add option to set auth as a url query string

### DIFF
--- a/mtz-auth-interceptor.html
+++ b/mtz-auth-interceptor.html
@@ -72,6 +72,8 @@ An implementation of the mtz.InterceptorBehavior that injects auth headers based
         } else if (this.setQueryParam) {
           // Append auth as a query param on the url
           let url = event.detail.url;
+          if (!url) return
+
           const bindingChar = url.indexOf('?') >= 0 ? '&' : '?';
 
           let key = this.key.replace('-', '');

--- a/mtz-auth-interceptor.html
+++ b/mtz-auth-interceptor.html
@@ -37,6 +37,10 @@ An implementation of the mtz.InterceptorBehavior that injects auth headers based
           type: Boolean,
           value: false,
         },
+        setQueryParam: {
+          type: Boolean,
+          value: false,
+        },
       },
       /**
        * Checks the event to see if event.target has with-auth set, if so then _applyHeader is called.
@@ -48,24 +52,36 @@ An implementation of the mtz.InterceptorBehavior that injects auth headers based
         // Fallback for 1.x, use composedPath or rootTarget for 2.0
         const target = event.composedPath && (event.composedPath()[0] || Polymer.dom(event).rootTarget) || event.target;
         if (target.getAttribute('with-auth') === '')
-          this._applyHeader(event, eventName);
+          this._applyAuth(event, eventName);
       },
       /**
-       * Attaches a header to the ajax request.
+       * Attaches a auth to the ajax request.
        * @protected
        *
        * @param {CustomEvent} event
        * @param {String} eventName
        */
-      _applyHeader(event, eventName) {
+      _applyAuth(event, eventName) {
         const path = (this.events.find((item) => item.name === eventName) || {}).path;
-        if (path) {
-          if (!this.setRequestHeader) {
-            this.set(`${path}.${this.key}`, this.value, event);
-          } else {
-            const xhr = this.get(path, event);
-            xhr.setRequestHeader(this.key, this.value);
-          }
+        if (!path) return;
+
+        if (this.setRequestHeader) {
+          // Apply auth to the xhr request header
+          const xhr = this.get(path, event);
+          xhr.setRequestHeader(this.key, this.value);
+        } else if (this.setQueryParam) {
+          // Append auth as a query param on the url
+          let url = event.detail.url;
+          const bindingChar = url.indexOf('?') >= 0 ? '&' : '?';
+
+          let key = this.key.replace('-', '');
+          key = key.charAt(0).toLowerCase() + key.slice(1);
+
+          url = `${url}${bindingChar}${key}=${this.value}`;
+          this.set(path, url, event);
+        } else {
+          // Apply auth to the designated path on the object
+          this.set(`${path}.${this.key}`, this.value, event);
         }
       }
     });

--- a/test/mtz-auth-interceptor_test.html
+++ b/test/mtz-auth-interceptor_test.html
@@ -34,6 +34,14 @@
           },
           composed: true,
         });
+        const urlRewriteEvent = new CustomEvent(urlRewriteEventName = 'ci-url-rewrite', {
+          detail: {
+            url: 'testing'
+          },
+          composed: true,
+        })
+        console.log('urlRewriteEvent')
+        console.log(urlRewriteEvent)
 
         beforeEach(() => {
           event.detail.options.headers = {};
@@ -45,6 +53,9 @@
           element.events.push({
             name: 'vaadin-request',
             path: 'detail.xhr',
+          },{
+            name: 'ci-url-rewrite',
+            path: 'detail.url',
           });
         });
         afterEach(() => {
@@ -54,36 +65,44 @@
         /* Public Methods */
         describe('intercept(event, eventName)', () => {
           beforeEach(() => {
-            element._applyHeader = sinon.spy();
+            element._applyAuth = sinon.spy();
           });
           afterEach(() => {
             el.removeAttribute('with-auth');
           });
 
-          it('should not call _applyHeader when event.target does not have with-auth', () => {
+          it('should not call _applyAuth when event.target does not have with-auth', () => {
             element.intercept(event, eventName);
-            expect(element._applyHeader.called).to.equal(false);
+            expect(element._applyAuth.called).to.equal(false);
           });
-          it('should call _applyHeader when event.target has with-auth', () => {
+          it('should call _applyAuth when event.target has with-auth', () => {
             el.setAttribute('with-auth', '');
             element.intercept(event, eventName);
-            expect(element._applyHeader.calledWithMatch(event, eventName)).to.equal(true);
+            expect(element._applyAuth.calledWithMatch(event, eventName)).to.equal(true);
           });
         });
         /* Protected Methods */
-        describe('_applyHeader(event, eventName)', () => {
+        describe.only('_applyAuth(event, eventName)', () => {
           it('should update path[key] with the value on event when a path is found', () => {
             element.key = 'key';
             element.value = 'value';
-            element._applyHeader(event, eventName);
+            element._applyAuth(event, eventName);
             expect(event.detail.options.headers[element.key]).to.equal(element.value);
           });
           it('should set the request header when setRequestHeader attr is set', () => {
             element.key = 'key';
             element.value = 'value';
             element.setRequestHeader = true;
-            element._applyHeader(vaadinEvent, vaadinEventName);
+            element._applyAuth(vaadinEvent, vaadinEventName);
             expect(vaadinEvent.detail.xhr.setRequestHeader).to.have.been.calledWith(element.key, element.value);
+          });
+          it.only('should append a query param when setQueryParam attr is set', () => {
+            element.key = 'key';
+            element.value = 'value';
+            element.setQueryParam = true;
+            const initialUrl = urlRewriteEvent.detail.url
+            element._applyAuth(urlRewriteEvent, urlRewriteEventName);
+            expect(urlRewriteEvent.detail.url).to.equal(initialUrl + '?' + element.key + '=' + element.value)
           });
         });
       });


### PR DESCRIPTION
Add option to set auth as a url query string instead of just in request headers.  This gives us the ability to add auth to non ajax get requests.   

Need to set `set-query-param` when adding `<mtz-auth-interceptor>`.